### PR TITLE
Fix SoftKey Transact return body

### DIFF
--- a/packages/webapp/src/_app/eos/ual/softkey/softkey-user.ts
+++ b/packages/webapp/src/_app/eos/ual/softkey/softkey-user.ts
@@ -145,13 +145,20 @@ export class SoftkeyUser extends User {
         config?: SignTransactionConfig
     ): Promise<SignTransactionResponse> {
         try {
-            const result = await this.api?.transact(transaction, {
+            const finalConfig = {
                 blocksBehind: 3,
                 expireSeconds: 30,
                 broadcast: true,
                 ...config,
-            });
-            return result;
+            };
+            const completedTransaction = await this.api?.transact(
+                transaction,
+                finalConfig
+            );
+            return this.returnEosjsTransaction(
+                finalConfig.broadcast,
+                completedTransaction
+            );
         } catch (e) {
             throw new UALSoftkeyError(
                 `Error signing transaction: ${e.message}`,


### PR DESCRIPTION
It fixes the return body of the signTransaction allowing us to process file uploads since it needs to read the serialized transaction and we didnt return it properly before.