### PR TITLE
Add loader component to member chip profile images

### DIFF
--- a/packages/webapp/src/_app/ui/image.tsx
+++ b/packages/webapp/src/_app/ui/image.tsx
@@ -1,10 +1,16 @@
-import { ImgHTMLAttributes, useState } from "react";
+import React, { ImgHTMLAttributes, useState } from "react";
 
 interface Props extends ImgHTMLAttributes<HTMLImageElement> {
     fallbackImage?: string;
+    loaderComponent?: React.ReactNode;
 }
 
-export const Image = ({ fallbackImage, ...imgProps }: Props) => {
+export const Image = ({
+    fallbackImage,
+    loaderComponent,
+    ...imgProps
+}: Props) => {
+    const [isLoaded, setIsLoaded] = useState<boolean>(false);
     const [src, setSrc] = useState(imgProps.src);
 
     const onError = (e: React.SyntheticEvent<HTMLImageElement, Event>) => {
@@ -17,5 +23,28 @@ export const Image = ({ fallbackImage, ...imgProps }: Props) => {
         }
     };
 
-    return <img {...imgProps} src={src} onError={onError} />;
+    const onLoad = (e: React.SyntheticEvent<HTMLImageElement, Event>) => {
+        setIsLoaded(true);
+
+        if (imgProps.onLoad) {
+            imgProps.onLoad(e);
+        }
+    };
+
+    if (!loaderComponent) {
+        return <img {...imgProps} src={src} onError={onError} />;
+    }
+
+    return (
+        <>
+            {!isLoaded && loaderComponent}
+            <img
+                {...imgProps}
+                src={src}
+                onError={onError}
+                onLoad={onLoad}
+                className={`${imgProps.className} ${isLoaded ? "" : "hidden"}`}
+            />
+        </>
+    );
 };

--- a/packages/webapp/src/_app/ui/profile-image.tsx
+++ b/packages/webapp/src/_app/ui/profile-image.tsx
@@ -1,4 +1,8 @@
+import React, { CSSProperties } from "react";
+import { FaSpinner } from "react-icons/fa";
+
 import { ipfsUrl } from "_app";
+
 import { Image } from "./image";
 
 interface ProfileImageProps {
@@ -15,14 +19,16 @@ export const ProfileImage = ({
     size = 56,
 }: ProfileImageProps) => {
     const imageClass = "rounded-full object-cover shadow";
+    const imageSize = { height: size, width: size };
     if (imageCid) {
         return (
             <div className="relative group" onClick={onClick}>
                 <Image
                     src={ipfsUrl(imageCid)}
-                    fallbackImage={"/images/avatars/fallback/avatar-6.svg"}
+                    fallbackImage="/images/avatars/fallback/avatar-6.svg"
+                    loaderComponent={<ImageLoader style={imageSize} />}
                     className={imageClass}
-                    style={{ height: size, width: size }}
+                    style={imageSize}
                 />
                 <div className="absolute inset-0 bg-black opacity-0 group-hover:opacity-20 transition rounded-full" />
                 {badge && (
@@ -35,9 +41,15 @@ export const ProfileImage = ({
         <Image
             src={"/images/unknown-member.png"}
             className={imageClass}
-            style={{ height: size, width: size }}
+            style={imageSize}
         />
     );
 };
 
 export default ProfileImage;
+
+const ImageLoader = ({ style }: { style: CSSProperties }) => (
+    <div className="flex justify-center items-center" style={style}>
+        <FaSpinner size={28} className="animate-spin text-gray-400" />
+    </div>
+);


### PR DESCRIPTION
## In this PR
Adds loader components to member profile images in member chips. These IPFS images can be large, and with infinite scroll, users will be more likely to see member chips with missing images. This adds a friendly loading placeholder for those images.

## Screen captures
![image](https://user-images.githubusercontent.com/7911424/138756305-5f6d1675-4d52-41db-94a2-439d9091e8e2.png)
