### PR TITLE
Front end bug fixes

### DIFF
--- a/packages/webapp/src/_app/ui/nav-profile.tsx
+++ b/packages/webapp/src/_app/ui/nav-profile.tsx
@@ -16,10 +16,10 @@ interface Props {
 }
 
 export const NavProfile = ({ location }: Props) => {
-    const [_ualAccount, _, ualShowModal] = useUALAccount();
+    const [ualAccount, _, ualShowModal] = useUALAccount();
     const { data: member } = useCurrentMember();
 
-    if (!member?.accountName) {
+    if (!ualAccount) {
         return (
             <div className="flex justify-end xs:justify-center md:justify-end xl:justify-start mb-0 xs:mb-8 my-0">
                 <Button
@@ -72,7 +72,9 @@ export const NavProfile = ({ location }: Props) => {
                         <Text size="sm" className="font-semibold">
                             {member?.profile?.name ?? "Not a member"}
                         </Text>
-                        <Text size="sm">@{member?.accountName}</Text>
+                        <Text size="sm">
+                            @{member?.accountName ?? ualAccount?.accountName}
+                        </Text>
                     </div>
                 </div>
             </PopoverWrapper>
@@ -84,7 +86,7 @@ export default NavProfile;
 
 interface PopoverProps extends Props {
     children: React.ReactNode;
-    member?: Member;
+    member?: Member | null;
 }
 
 const PopoverWrapper = ({ children, member, location }: PopoverProps) => {

--- a/packages/webapp/src/nfts/api/nfts.ts
+++ b/packages/webapp/src/nfts/api/nfts.ts
@@ -25,7 +25,7 @@ export const getTemplates = async (
 export const getAccountCollection = async (
     account: string,
     page = 1,
-    limit = 9999,
+    limit = 100,
     sortField = "transferred",
     order = "asc"
 ): Promise<AssetData[]> => {

--- a/packages/webapp/src/treasury/components/treasury-delegate-levels-info.tsx
+++ b/packages/webapp/src/treasury/components/treasury-delegate-levels-info.tsx
@@ -68,6 +68,7 @@ export const TreasuryDelegateLevelsInfo = () => {
                 label={label}
                 level={index + 1}
                 amount={rankAmount}
+                key={`rank-level-${label}`}
             />
         );
     };


### PR DESCRIPTION
This PR fixes the following issues:

- If user signs in as a non-member EOS account, they cannot sign out without clearing local storage. This was a regression introduced in a prior refactor.
- A member's NFT collection was not displaying; it was trying to fetch more items than allowed by the AtomicMarket API (a limit which they randomly began enforcing). We fixed this previously for a member's list of collectORS, but not for their collectION.
- Console was complaining that a React component key was missing from a component on the Treasury page.

Note: Each commit maps 1:1 with a bug above, so it's likely easiest to review this commit-by-commit.