### PR TITLE
Fixes induction preview image and video ceremony link.

### DIFF
--- a/packages/webapp/src/inductions/utils.ts
+++ b/packages/webapp/src/inductions/utils.ts
@@ -23,7 +23,9 @@ export const convertPendingProfileToMember = (
         name: profile.name,
         image: {
             cid: profile.img,
-            url: ipfsUrl(profile.img),
+            url: profile.img.startsWith("blob:")
+                ? profile.img
+                : ipfsUrl(profile.img),
             attributions: profile.attributions || "",
         },
         bio: profile.bio,

--- a/packages/webapp/src/members/components/member-card.tsx
+++ b/packages/webapp/src/members/components/member-card.tsx
@@ -24,7 +24,7 @@ export const MemberCard = ({ member, showBalance }: Props) => {
             </Container>
             <Container>
                 <MemberBio bio={member.profile.bio} />
-                {member.inductionVideo && (
+                {member.inductionVideo.url && (
                     <SocialButton
                         handle="Induction Ceremony"
                         icon={FaVideo}


### PR DESCRIPTION
Issues flagged recently in "Eden-Dev" Telegram channel relating to new inductions:
1. Profile images do not display in profile preview before user submits profile
2. The "🎥 Induction ceremony" link displays before an induction video has even been uploaded

This PR fixes those.

<img width="987" alt="image" src="https://user-images.githubusercontent.com/7911424/160495027-d687da41-a7ce-44be-966b-ae2599e82eff.png">