### PR TITLE
Make UI reflect video upload deadline change in contract.

### DIFF
--- a/packages/webapp/src/elections/components/ongoing-election-components/video-upload-button.tsx
+++ b/packages/webapp/src/elections/components/ongoing-election-components/video-upload-button.tsx
@@ -41,7 +41,7 @@ export const VideoUploadButton = ({ buttonType }: Props) => {
                 <div className="space-y-3">
                     <Text>
                         The election video upload service will open in a new
-                        browser tab. It is available during the 48 hours after
+                        browser tab. It is available during the 2 weeks after
                         the beginning of the election. Any election videos must
                         be uploaded during this period.
                     </Text>

--- a/packages/webapp/src/pages/election/round-video-upload.tsx
+++ b/packages/webapp/src/pages/election/round-video-upload.tsx
@@ -79,7 +79,7 @@ export const RoundVideoUploadPage = () => {
                                 is complete.
                             </Text>
                             <Text>
-                                Be patient, and remember you have 48 hours from
+                                Be patient, and remember you have 2 weeks from
                                 the beginning of the election to complete your
                                 election video uploads.
                             </Text>


### PR DESCRIPTION
Election UI still says that videos must be uploaded within 48 hours after the beginning of the election. However, the contract (and UI logic) now has this set at 2 weeks. This fixes that.