### PR TITLE
Don't crash webapp when displaying resigned members in election stats.

### DIFF
--- a/packages/webapp/src/members/helpers/formatters.ts
+++ b/packages/webapp/src/members/helpers/formatters.ts
@@ -10,14 +10,19 @@ export const formatMembersQueryNodeAsMemberNFT = (
     data: MembersQueryNode
 ): MemberNFT | undefined => {
     if (!data) return;
+
+    if (!data.profile) {
+        console.info(`${data.account} has since resigned`);
+    }
+
     return {
         createdAt: data.createdAt ? new Date(data.createdAt).getTime() : 0,
         account: data.account,
-        name: data.profile.name,
-        image: data.profile.img,
-        attributions: data.profile.attributions,
-        bio: data.profile.bio,
-        socialHandles: JSON.parse(data.profile.social),
+        name: data.profile?.name ?? data.account,
+        image: data.profile?.img,
+        attributions: data.profile?.attributions,
+        bio: data.profile?.bio,
+        socialHandles: data.profile ? JSON.parse(data.profile.social) : {},
         inductionVideo: data.inductionVideo,
     };
 };


### PR DESCRIPTION
The microchain graphql state does not retain a member's profile information after they resign. These members are still listed as having participated in the election (and rightfully so). The election stats page, however, didn't properly handle members with no profile information.

<img width="441" alt="image" src="https://user-images.githubusercontent.com/7911424/162796683-c22de896-96a8-42ce-8655-7d2d358d2941.png">
